### PR TITLE
Remove Nunito font

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "styled-components": "^3.4.10",
     "typeface-dancing-script": "0.0.54",
     "typeface-josefin-sans": "0.0.54",
-    "typeface-nunito": "0.0.54",
     "typeface-quicksand": "0.0.71",
     "typeface-roboto": "0.0.54",
     "typeface-source-sans-pro": "0.0.54"

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,7 @@ injectGlobal`
   body {
     height: 100%;
     width: 100%;
-    font-family: Nunito, Helvetica Neue, Helvetica, Arial, sans-serif;
+    font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
   }
 `;
 

--- a/src/Restaurant/LaCarteLayer.js
+++ b/src/Restaurant/LaCarteLayer.js
@@ -109,7 +109,6 @@ const styles = {
     textAlign: 'left',
   },
   price: {
-    fontFamily: 'Nunito',
     color: '#4CAF50',
     fontWeight: 'bold',
     fontSize: '0.9em',

--- a/src/Restaurant/LaCarteLayerEn.js
+++ b/src/Restaurant/LaCarteLayerEn.js
@@ -99,7 +99,6 @@ const styles = {
     textAlign: 'left',
   },
   price: {
-    fontFamily: 'Nunito',
     color: '#4CAF50',
     fontWeight: 'bold',
     fontSize: '0.9em',

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import { BrowserRouter as Router } from 'react-router-dom';
 
-import 'typeface-nunito';
 import 'typeface-dancing-script';
 import 'typeface-quicksand';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10636,11 +10636,6 @@ typeface-josefin-sans@0.0.54:
   resolved "https://registry.yarnpkg.com/typeface-josefin-sans/-/typeface-josefin-sans-0.0.54.tgz#c7f1c88d9a01605762465139ef9f485b42c306ff"
   integrity sha512-wpApRq22rGuK82Atg4T5Bei/3Yrjc9rdtDOadW5pOJs1eoyDrbb6GZ3ovWizjq8Va0Ak4TMUAgkYyag65w5xJw==
 
-typeface-nunito@0.0.54:
-  version "0.0.54"
-  resolved "https://registry.yarnpkg.com/typeface-nunito/-/typeface-nunito-0.0.54.tgz#5046f24d8d1492ca8fd823896d6e1cdefbe63203"
-  integrity sha512-hxC+o6vc0vkXPDNGRWZ26ghXPTzVC2gJbUGSJEmoMByb02yM94PiVOLoBa0ChC+HgNbAGbHeQh7k6ok+59gjZw==
-
 typeface-quicksand@0.0.71:
   version "0.0.71"
   resolved "https://registry.yarnpkg.com/typeface-quicksand/-/typeface-quicksand-0.0.71.tgz#85157b7cc299b558dbeeea1a413217887685dd6b"


### PR DESCRIPTION
Cette font n'était utilisée que sur le prix.

Pour aller plus loin et avoir le check en green, il faudrait utiliser la police "sans-serif" des browsers. En jouant sur la taille, je pense qu'on peut retrouver l'effet de la font actuelle, "quicksand".

Avec ça, plus d'appel réseau pour les fonts :)